### PR TITLE
Manage focus between page loads

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -20,6 +20,10 @@ body {
   line-height: 22px;
 }
 
+h1 {
+  outline: 0;
+}
+
 [data-hidden] {
   display: none !important;
 }

--- a/app/javascript/components/focus.js
+++ b/app/javascript/components/focus.js
@@ -1,0 +1,18 @@
+export function handleLoadFocus() {
+  const alert = document.querySelector("[data-alert]");
+
+  if (alert) {
+    alert.tabIndex = -1;
+    alert.focus();
+    return;
+  }
+
+  const heading = document.querySelector("h1");
+
+  if (heading) {
+    heading.focus();
+    return;
+  }
+}
+
+document.addEventListener("turbolinks:load", handleLoadFocus);

--- a/app/javascript/components/heading.js
+++ b/app/javascript/components/heading.js
@@ -1,0 +1,9 @@
+export function focusHeading() {
+  const heading = document.querySelector("h1");
+
+  if (heading) {
+    heading.focus();
+  }
+}
+
+document.addEventListener("turbolinks:load", focusHeading);

--- a/app/javascript/components/heading.js
+++ b/app/javascript/components/heading.js
@@ -1,9 +1,0 @@
-export function focusHeading() {
-  const heading = document.querySelector("h1");
-
-  if (heading) {
-    heading.focus();
-  }
-}
-
-document.addEventListener("turbolinks:load", focusHeading);

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -1,4 +1,5 @@
 export { initializeCodeGenerator } from "./code-generator";
 export { Form } from "./form";
+export { Heading } from "./heading";
 export { Modal } from "./modal";
 export { initializePopovers } from "./popover";

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -1,5 +1,5 @@
 export { initializeCodeGenerator } from "./code-generator";
 export { Form } from "./form";
-export { Heading } from "./heading";
+export { Focus } from "./focus";
 export { Modal } from "./modal";
 export { initializePopovers } from "./popover";

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
   <div class="page__container">
     <div class="page__header">
       <div class="visually-hidden">
-        <h1><%= t('home.title')%></h1>
+        <h1 tabindex="-1"><%= t('home.title')%></h1>
       </div>
     </div>
     <div class="page__content">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="visually-hidden"><%= t('sign_in.title') %></h1>
+<h1 class="visually-hidden" tabindex="-1"><%= t('sign_in.title') %></h1>
 
 <div class="login">
   <%= form_tag sessions_path do |form| %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="card__body">
         <% if alert %>
-          <div class="error" id="alert"><%= alert %></div>
+          <div class="error" id="alert" data-alert><%= alert %></div>
         <% end %>
         <div class="text-field">
           <%= label_tag :username, t('sign_in.username'), class: 'text-field__label' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="page">
   <div class="page__container">
     <div class="page__header">
-      <h1 class="page__title">
+      <h1 class="page__title" tabindex="-1">
         <% if current_user == @user %>
           <%= t('settings.title') %>
         <% else %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <div class="page">
   <div class="page__container">
     <div class="page__header">
-      <h1 class="page__title"><%= t('users_index.title') %></h1>
+      <h1 class="page__title" tabindex="-1"><%= t('users_index.title') %></h1>
       <div class="page__action">
         <%= link_to t('users_index.add_button'), new_user_path, class: 'button button--primary' %>
       </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="page">
   <div class="page__container">
     <div class="page__header">
-      <h1 class="page__title"><%= t('add_user.title') %></h1>
+      <h1 class="page__title" tabindex="-1"><%= t('add_user.title') %></h1>
     </div>
     <div class="page__content">
       <%= render 'form', user: @user, button_text: t('add_user.add_user_button') %>


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/8.

It adds a tabindex of `-1` to h1s and programmatically focuses them on page changes.