### PR TITLE
Adding appropriate role and markup for code banner

### DIFF
--- a/app/assets/stylesheets/components/code-generator.scss
+++ b/app/assets/stylesheets/components/code-generator.scss
@@ -25,6 +25,10 @@
   letter-spacing: 0;
 }
 
+.code-generator__result {
+  font-weight: normal;
+}
+
 .code-generator__empty-banner::before {
   display: block;
   content: "\25CF\25CF\25CF\25CF\0020\25CF\25CF\25CF\25CF";

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -67,8 +67,8 @@
               <div class="ordered-list__item-content">
                 <div><%= t('home.card2.step4') %></div>
                 <div class="code-generator">
-                  <div id="code-result" class="code-generator__banner" data-code-banner>
-                    <div data-code-result aria-live="polite"></div>
+                  <div id="code-result" class="code-generator__banner" role="region" aria-label="<%= t('home.card2.step4_generated_code') %>" data-code-banner>
+                    <strong class="code-generator__result" data-code-result aria-live="polite"></strong>
                     <div aria-hidden="true" class="code-generator__empty-banner" data-code-empty-result></div>
                   </div>
                   <div class="code-generator__banner code-generator__banner--expired" data-code-expired data-hidden>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
       step4: "In the code field, enter:"
       step4_code_expired: "This code has expired."
       step4_generate_code: "Generate code"
+      step4_generated_code: "Generated code"
       step4_generate_new_code: "Generate new code"
       step5_html: 'Tap the <code class="inline-code">I agree</code> button'
       step5_modal_title: "Step 5"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -62,6 +62,7 @@ fr:
       step4: "In the code field, enter:"
       step4_code_expired: "This code has expired."
       step4_generate_code: "Generate code"
+      step4_generated_code: "Generated code"
       step4_generate_new_code: "Generate new code"
       step5_html: 'Tap the <code class="inline-code">I agree</code> button'
       step5_modal_title: "Step 5"


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/16.

It adds the appropriate role, aria label, and markup for the generated code.