### PR TITLE
Fix menu navigation semantics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ module ApplicationHelper
     if request.path == path
       content_tag(:span, class: 'popover__link popover__link--active', &block)
     else
-      link_to(path, class: 'popover__link', role: 'menuitem', &block)
+      link_to(path, class: 'popover__link', &block)
     end
   end
 

--- a/app/javascript/components/popover.js
+++ b/app/javascript/components/popover.js
@@ -14,7 +14,7 @@ export function initializePopovers() {
     activator.addEventListener("click", (event) => {
       event.stopPropagation();
       if (popover.dataset.popoverActive) {
-        activator.removeAttribute = "aria-expanded";
+        activator.setAttribute = ("aria-expanded", "false");
         delete popover.dataset.popoverActive;
         return;
       }

--- a/app/javascript/components/popover.js
+++ b/app/javascript/components/popover.js
@@ -14,13 +14,13 @@ export function initializePopovers() {
     activator.addEventListener("click", (event) => {
       event.stopPropagation();
       if (popover.dataset.popoverActive) {
-        activator.setAttribute = ("aria-expanded", "false");
+        activator.setAttribute("aria-expanded", "false");
         delete popover.dataset.popoverActive;
         return;
       }
 
       popover.dataset.popoverActive = true;
-      activator.setAttribute = ("aria-expanded", "true");
+      activator.setAttribute("aria-expanded", "true");
 
       addOnce(document, "click", () => delete popover.dataset.popoverActive);
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
           <div class="top-bar__group">
             <div class="popover" data-popover>
               <button id="menu-button" type="button" class="top-bar__link" data-popover-activator aria-controls="menu-popover" aria-expanded="false">
-                <%= t('nav.menu') %>
+                <%= t('menu') %>
               </button>
               <div class="popover__content" data-popover-content>
                 <nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,27 +28,27 @@
           </div>
           <div class="top-bar__group">
             <div class="popover" data-popover>
-              <button id="menu-button" type="button" class="top-bar__link" data-popover-activator aria-controls="menu-popover" aria-haspopup="true">
+              <button id="menu-button" type="button" class="top-bar__link" data-popover-activator aria-controls="menu-popover" aria-expanded="false">
                 <%= t('nav.menu') %>
               </button>
               <div class="popover__content" data-popover-content>
                 <nav>
-                  <ul id="menu-popover" class="popover__list" role="menu" aria-labelledby="menu-button">
+                  <ul id="menu-popover" class="popover__list" role="list" aria-labelledby="menu-button">
                     <% if current_user.admin %>
-                      <li role="none">
+                      <li>
                         <%= nav_item(users_path) do %>
                           <svg class="popover__icon"><use xlink:href="#users" /></svg>
                           <%= t('manage_users') %>
                         <% end %>
                       </li>
                     <% end %>
-                    <li role="none">
+                    <li>
                       <%= nav_item(edit_user_path(current_user)) do %>
                         <svg class="popover__icon"><use xlink:href="#settings" /></svg>
                         <%= t('settings.title') %>
                       <% end %>
                     </li>
-                    <li role="none">
+                    <li>
                       <%= nav_item(logout_path) do %>
                         <svg class="popover__icon"><use xlink:href="#logout" /></svg>
                         <%= t('sign_out') %>


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/9.

It updates the menu popover attributes to convey the correct semantics