### PR TITLE
Adding error announcements to user form

### DIFF
--- a/app/javascript/components/focus.js
+++ b/app/javascript/components/focus.js
@@ -7,6 +7,13 @@ export function handleLoadFocus() {
     return;
   }
 
+  const firstError = document.querySelector("[aria-invalid]");
+
+  if (firstError) {
+    firstError.focus();
+    return;
+  }
+
   const heading = document.querySelector("h1");
 
   if (heading) {

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -12,9 +12,13 @@
         <div class="grid__item grid__item--half">
           <div class="<%= text_field_classes(user.errors[:username]) %>">
             <%= form.label :username, t('username'), class: 'text-field__label' %>
-            <%= form.text_field :username, class: 'text-field__input' %>
+            <%= form.text_field :username,
+              class: 'text-field__input',
+              'aria-describedby': (user.errors[:username].any? ? 'username-error' : nil),
+              'aria-invalid': (user.errors[:username].any? ? true : nil)
+            %>
             <% if user.errors[:username].any? %>
-              <div class="text-field__error-message">
+              <div id="usrname-error" class="text-field__error-message">
                 <%= user.errors[:username].join(',') %>
               </div>
             <% end %>
@@ -26,9 +30,14 @@
         <div class="grid__item grid__item--half">
           <div class="<%= text_field_classes(user.errors[:password]) %>">
             <%= form.label :password, t('password'), class: 'text-field__label' %>
-            <%= form.password_field :password, class: 'text-field__input', autocomplete: 'new-password' %>
+            <%= form.password_field :password,
+              class: 'text-field__input',
+              autocomplete: 'new-password',
+              'aria-describedby': (user.errors[:password].any? ? 'password-error' : nil),
+              'aria-invalid': (user.errors[:password].any? ? true : nil)
+            %>
             <% if user.errors[:password].any? %>
-              <div class="text-field__error-message">
+              <div id="password-error" class="text-field__error-message">
                 <%= user.errors[:password].join(',') %>
               </div>
             <% end %>
@@ -38,9 +47,13 @@
         <div class="grid__item grid__item--half">
           <div class="<%= text_field_classes(user.errors[:password_confirmation]) %>">
             <%= form.label :password_confirmation, t('user_form.confirm_password'), class: 'text-field__label' %>
-            <%= form.password_field :password_confirmation, class: 'text-field__input' %>
+            <%= form.password_field :password_confirmation,
+              class: 'text-field__input',
+              'aria-describedby': (user.errors[:password_confirmation].any? ? 'password-confirmation-error' : nil),
+              'aria-invalid': (user.errors[:password_confirmation].any? ? true : nil)
+            %>
             <% if user.errors[:password_confirmation].any? %>
-              <div class="text-field__error-message">
+              <div id="password-confirmation-error" class="text-field__error-message">
                 <%= user.errors[:password_confirmation].join(',') %>
               </div>
             <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -18,9 +18,9 @@
               'aria-invalid': (user.errors[:username].any? ? true : nil)
             %>
             <% if user.errors[:username].any? %>
-              <div id="usrname-error" class="text-field__error-message">
+              <small id="username-error" class="text-field__error-message">
                 <%= user.errors[:username].join(',') %>
-              </div>
+              </small>
             <% end %>
           </div>
         </div>
@@ -37,9 +37,9 @@
               'aria-invalid': (user.errors[:password].any? ? true : nil)
             %>
             <% if user.errors[:password].any? %>
-              <div id="password-error" class="text-field__error-message">
+              <small id="password-error" class="text-field__error-message">
                 <%= user.errors[:password].join(',') %>
-              </div>
+              </small>
             <% end %>
           </div>
         </div>
@@ -53,9 +53,9 @@
               'aria-invalid': (user.errors[:password_confirmation].any? ? true : nil)
             %>
             <% if user.errors[:password_confirmation].any? %>
-              <div id="password-confirmation-error" class="text-field__error-message">
+              <small id="password-confirmation-error" class="text-field__error-message">
                 <%= user.errors[:password_confirmation].join(',') %>
-              </div>
+              </small>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/7.

It uses the suggestion in that issue to connect the error messages to the inputs using aria