### PR TITLE
Fix sign_in_as in test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,6 @@ class ActiveSupport::TestCase
   fixtures :all
 
   def sign_in_as(user)
-    post sessions_url(username: user.username, password: 'secret')
+    session[:user_id] = user.id
   end
 end


### PR DESCRIPTION
This fixes the sign_in_as test helper to not use a post