### PR TITLE
Make modal title ids unique

### DIFF
--- a/app/views/components/_modal.html.erb
+++ b/app/views/components/_modal.html.erb
@@ -1,13 +1,13 @@
 <div class="modal-backdrop" id="<%= id %>">
   <div
     class="modal"
-    aria-labelledby="modal-title"
+    aria-labelledby="modal-title-<%= id %>"
     role="dialog"
     aria-modal="true"
     tabIndex="-1"
   >
     <div class="modal__header">
-      <h2 id="modal-title" class="modal__title">
+      <h2 id="modal-title-<%= id %>" class="modal__title">
         <%= title %>
       </h2>
       <button


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/19.

It makes the modal title id unique based on the modal id itself.