### PR TITLE
Separate iOS and Android images for modal

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -129,8 +129,8 @@
                   <svg class="icon"><use xlink:href="#question-mark" /></svg>
                 </button>
                 <%= render 'components/modal', {id: 'step3-7', title: t('home.card3.step7_modal_title')} do %>
-                  <p><%= t('home.card3.step7_modal_content_html') %></p>
-                  <%= image_tag('step7.png', class: 'image', alt: t('home.card3.step7_modal_alt')) %>
+                  <p><%= t('home.card3.step7_modal_ios_content_html') %></p>
+                  <%= image_tag('step7.png', class: 'image', alt: t('home.card3.step7_modal_ios_alt')) %>
                 <% end %> 
               </div>
             </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,8 +79,10 @@ en:
       step6_modal_alt: "Screenshot of COVID Shield mobile app with I agree button highlighted"
       step7_html: 'Tap either <code class="inline-code">Allow</code> or <code class="inline-code">Share</code>.'
       step7_modal_title: "Step 7"
-      step7_modal_content_html: 'Tap either <code class="inline-code">Allow</code> or <code class="inline-code">Share</code>.'
-      step7_modal_alt: "Screenshot of iOS and Android permissions pop-ups"
+      step7_modal_ios_content_html: 'Tap <code class="inline-code">Allow</code>.'
+      step7_modal_ios_alt: "Screenshot of iOS permissions pop-ups"
+      step7_modal_android_content_html: 'Tap <code class="inline-code">Share</code>.'
+      step7_modal_android_alt: "Screenshot of Android permissions pop-ups"
       step8: "You don’t need to do anything else today. You will receive a notification each day for the next 13 days requesting your permission to share any new random IDs."
   users_index:
     title: "Manage users"


### PR DESCRIPTION
Change step7_modal_content_html and step7_modal_alt to step7_modal_ios_content_html / step7_modal_ios_alt / step7_modal_android_content_html / step7_modal_android_alt.

CC @annemarieleger @Guillaumegranger1 