### PR TITLE
Use unique aria-label for help modal activators

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -57,7 +57,7 @@
             <li class="ordered-list__item">
               <div class="ordered-list__item-content">
                 <span><%= t('home.card3.step2') %></span>
-                <button aria-label="<%= t('more_info') %>" class="help__activator" type="button" data-modal-activator="step2-2" aria-haspopup="dialog">
+                <button aria-label="<%= t('more_info') %>, <%= t('home.card3.step2_modal_title') %>" class="help__activator" type="button" data-modal-activator="step2-2" aria-haspopup="dialog">
                   <svg class="icon"><use xlink:href="#question-mark" /></svg>
                 </button>
                 <%= render 'components/modal', {id: 'step2-2', title: t('home.card3.step2_modal_title')} do %>
@@ -69,7 +69,7 @@
             <li class="ordered-list__item">
               <div class="ordered-list__item-content">
                 <%= t('home.card3.step3_html') %>
-                <button aria-label="<%= t('more_info') %>" class="help__activator" type="button" data-modal-activator="step2-3" aria-haspopup="dialog">
+                <button aria-label="<%= t('more_info') %>, <%= t('home.card3.step3_modal_title') %>" class="help__activator" type="button" data-modal-activator="step2-3" aria-haspopup="dialog">
                   <svg class="icon"><use xlink:href="#question-mark" /></svg>
                 </button>
                 <%= render 'components/modal', {id: 'step2-3', title: t('home.card3.step3_modal_title')} do %>
@@ -86,7 +86,7 @@
                     <strong class="code-generator__result" data-code-result aria-live="polite"></strong>
                     <div aria-hidden="true" class="code-generator__empty-banner" data-code-empty-result></div>
                   </div>
-                  <div class="code-generator__banner code-generato r__banner--expired" data-code-expired data-hidden>
+                  <div class="code-generator__banner code-generator__banner--expired" data-code-expired data-hidden>
                     <%= t('home.card3.step4_code_expired') %>
                   </div>
                   <div class="code-generator__button">
@@ -101,7 +101,7 @@
             <li class="ordered-list__item">
               <div class="ordered-list__item-content">
                 <%= t('home.card3.step5_html') %>
-                <button aria-label="<%= t('more_info') %>" class="help__activator" type="button" data-modal-activator="step3-5" aria-haspopup="dialog">
+                <button aria-label="<%= t('more_info') %>, <%= t('home.card3.step5_modal_title') %>" class="help__activator" type="button" data-modal-activator="step3-5" aria-haspopup="dialog">
                   <svg class="icon"><use xlink:href="#question-mark" /></svg>
                 </button>
                 <%= render 'components/modal', {id: 'step3-5', title: t('home.card3.step5_modal_title')} do %>
@@ -113,7 +113,7 @@
             <li class="ordered-list__item">
               <div class="ordered-list__item-content">
                 <%= t('home.card3.step6_html') %>
-                <button aria-label="<%= t('more_info') %>" class="help__activator" type="button" data-modal-activator="step3-6" aria-haspopup="dialog">
+                <button aria-label="<%= t('more_info') %>, <%= t('home.card3.step6_modal_title') %>" class="help__activator" type="button" data-modal-activator="step3-6" aria-haspopup="dialog">
                   <svg class="icon"><use xlink:href="#question-mark" /></svg>
                 </button>
                 <%= render 'components/modal', {id: 'step3-6', title: t('home.card3.step6_modal_title')} do %>
@@ -125,7 +125,7 @@
             <li class="ordered-list__item">
               <div class="ordered-list__item-content">
                 <%= t('home.card3.step7_html') %>
-                <button aria-label="<%= t('more_info') %>" class="help__activator" type="button" data-modal-activator="step3-7" aria-haspopup="dialog">
+                <button aria-label="<%= t('more_info') %>, <%= t('home.card3.step7_modal_title') %>" class="help__activator" type="button" data-modal-activator="step3-7" aria-haspopup="dialog">
                   <svg class="icon"><use xlink:href="#question-mark" /></svg>
                 </button>
                 <%= render 'components/modal', {id: 'step3-7', title: t('home.card3.step7_modal_title')} do %>


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/20.

It changes the aria label for each help modal activator to also include the modal title so that it is more clear which one it is referring too.