### PR TITLE
Remove user-scalable=0 in viewport meta tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, minimum-scale=1.0, user-scalable=0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, minimum-scale=1.0">
 
     <%= stylesheet_link_tag 'https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;700&display=swap' %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/14.

It removes the `user-scalable=0` in the viewport meta tag.