### PR TITLE
Adds custom confirm modal for user removal

### DIFF
--- a/app/assets/stylesheets/components/link.scss
+++ b/app/assets/stylesheets/components/link.scss
@@ -4,6 +4,11 @@
   transition: box-shadow 100ms ease-out;
   border-radius: $border-radius;
   padding: 2px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-size: 14px;
+  cursor: pointer;
 
   &:hover {
     text-decoration: underline;

--- a/app/views/components/_modal.html.erb
+++ b/app/views/components/_modal.html.erb
@@ -23,7 +23,11 @@
       <%= yield %>
     </div>
     <div class="modal__footer">
-      <button class="button" type="button" data-modal-close>Close</Button>
+      <% if local_variables.include?(:footer)%>
+        <%= footer %>
+      <% else %>
+        <button class="button" type="button" data-modal-close>Close</Button>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,7 +35,22 @@
                 </td>
                 <td class="index__cell" width="1">
                   <% if user != current_user %>
-                    <%= link_to t('users_index.remove'), user, class: 'link', method: :delete, data: { confirm: t('users_index.confirm_delete') } %>
+                    <button class="link" type="button" data-modal-activator="remove-user-<%= user.id %>" aria-haspopup="dialog">
+                      <%= t('users_index.remove') %>
+                    </button>
+                    <% 
+                      @footer = capture do
+                        link_to t('users_index.remove_user'), user, class: 'button button--primary', method: :delete
+                      end
+                    %>
+                    <%= render 'components/modal', {
+                      id: "remove-user-#{user.id}",
+                      title: t('users_index.remove_user'),
+                      footer: @footer
+                    } do %>
+                      <p><%= t('users_index.confirm_delete_html', user: user.username) %></p>
+                      <p><%= t('users_index.cannot_be_undone') %></p>
+                    <% end %> 
                   <% end %>
                 </td>
               </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,7 +89,9 @@ en:
     add_button: "Add user"
     edit: "Edit"
     remove: "Remove"
-    confirm_delete: "Are you sure you want to remove this user?"
+    remove_user: "Remove user"
+    confirm_delete_html: "You are about to remove <strong>%{user}</strong>."
+    cannot_be_undone: "This cannot be undone."
   user_form:
     confirm_password: "Confirm password"
     permissions_label: "User permissions"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -73,7 +73,9 @@ fr:
     add_button: "Add user"
     edit: "Edit"
     remove: "Remove"
-    confirm_delete: "Are you sure you want to remove this user?"
+    remove_user: "Remove user"
+    confirm_delete_html: "You are about to remove <strong>%{user}</strong>."
+    cannot_be_undone: "This cannot be undone."
   user_form:
     confirm_password: "Confirm password"
     permissions_label: "User permissions"


### PR DESCRIPTION
This updates the confirmation on user removal to use our custom dialog.

This also adds a few new strings to the translation files that we need for it.

<img width="602" alt="Screen Shot 2020-05-20 at 2 48 34 PM" src="https://user-images.githubusercontent.com/478990/82485527-91884980-9aa9-11ea-85ab-4f591ad55379.png">
