### PR TITLE
Increase contrast on input borders

### DIFF
--- a/app/assets/stylesheets/components/popover.scss
+++ b/app/assets/stylesheets/components/popover.scss
@@ -12,7 +12,7 @@
   border: 1px solid $color-border;
   top: calc(100% + #{$spacing-tight});
   right: 0;
-  width: 170px;
+  width: 180px;
 
   [data-popover-active] & {
     display: block;

--- a/app/assets/stylesheets/components/radio-button.scss
+++ b/app/assets/stylesheets/components/radio-button.scss
@@ -45,7 +45,7 @@ $radio-border-size: 1px;
 
 .radio-button__target {
   background-color: transparent;
-  border: $radio-border-size solid $color-border;
+  border: $radio-border-size solid $color-input-border;
   width: $radio-size + $radio-padding + ($radio-border-size * 2);
   height: $radio-size + $radio-padding + ($radio-border-size * 2);
   padding: ($radio-padding / 2);

--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -7,7 +7,7 @@ $caret-size: 8px;
   padding: $spacing-tight;
   width: 100%;
   margin: 0;
-  border: 1px solid $color-border;
+  border: $border-input;
   border-radius: $border-radius;
   background-color: $color-white;
   -moz-appearance: none;

--- a/app/assets/stylesheets/components/text-field.scss
+++ b/app/assets/stylesheets/components/text-field.scss
@@ -13,7 +13,7 @@
   width: 100%;
   font-size: 14px;
   border-radius: $border-radius;
-  border: 1px solid $color-border;
+  border: $border-input;
   padding: 10px;
   transition: box-shadow 100ms ease-out;
 

--- a/app/assets/stylesheets/foundation.scss
+++ b/app/assets/stylesheets/foundation.scss
@@ -9,6 +9,7 @@ $color-white: #ffffff;
 $color-black: #000000;
 
 $color-border: #cfcfcf;
+$color-input-border: #949494;
 $color-background: #f5f5f5;
 $color-surface: #ffffff;
 $color-text: #212529;
@@ -27,6 +28,7 @@ $font-family: "Nunito Sans", sans-serif;
 
 /** Borders **/
 $border-default: 1px solid $color-border;
+$border-input: 1px solid $color-input-border;
 
 /** Border radii **/
 $border-radius: 4px;


### PR DESCRIPTION
This fixes https://github.com/CovidShield/portal/issues/11.

It updates the input border colors to give them a bit more contrast.

This is what it looks like now:

<img width="755" alt="Screen Shot 2020-05-21 at 9 17 16 AM" src="https://user-images.githubusercontent.com/478990/82564584-ff368300-9b46-11ea-9b90-aa27da3ac6bf.png">
