### PR TITLE
Fixing tests and adding github action to run them

### DIFF
--- a/.github/workflows/branch-docker-ci.yml
+++ b/.github/workflows/branch-docker-ci.yml
@@ -4,15 +4,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build docker image
-      env:
-        ECR_REPOSITORY: portal
-        IMAGE_TAG: ${{ github.sha }}
-        RAILS_ENV: production
-      run: |
-        docker build -t covidshield.app/ci/$ECR_REPOSITORY:$IMAGE_TAG .
-    - name: Container security scan
-      uses: Azure/container-scan@v0
-      with:
-        image-name: covidshield.app/ci/portal:${{ github.sha }}
+      - uses: actions/checkout@v2
+      - name: Build docker image
+        env:
+          ECR_REPOSITORY: portal
+          IMAGE_TAG: ${{ github.sha }}
+          RAILS_ENV: production
+        run: |
+          docker build -t covidshield.app/ci/$ECR_REPOSITORY:$IMAGE_TAG .
+      - name: Container security scan
+        uses: Azure/container-scan@v0
+        with:
+          image-name: covidshield.app/ci/portal:${{ github.sha }}

--- a/.github/workflows/branch-tests-ci.yml
+++ b/.github/workflows/branch-tests-ci.yml
@@ -1,0 +1,52 @@
+name: Tests
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: portal_test
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "2.7.1"
+      - name: Verify MySQL connection from host
+        run: |
+          sudo apt-get install -y mysql-client libmysqlclient-dev
+          mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} --user=root -e "SHOW GRANTS FOR 'root'@'localhost'"
+          mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} --user=root mysql
+      - name: Install dependencies
+        run: |
+          bundle install --jobs 4 --retry 3
+          yarn install
+      - name: Setup database
+        env:
+          RAILS_ENV: test
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: ${{ job.services.mysql.ports[3306] }}
+        run: |
+          bundle exec rails db:create
+          bundle exec rails db:migrate
+      - name: Run unit tests
+        env:
+          RAILS_ENV: test
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: ${{ job.services.mysql.ports[3306] }}
+          KEY_CLAIM_TOKEN: test
+          KEY_CLAIM_HOST: test.serverexample.com
+        run: bundle exec rails test
+      - name: Run system tests
+        env:
+          RAILS_ENV: test
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_PORT: ${{ job.services.mysql.ports[3306] }}
+          KEY_CLAIM_TOKEN: test
+          KEY_CLAIM_HOST: test.serverexample.com
+        run: bundle exec rails test:system

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 6.0.3.1'
-# Use mysql as the database for Active Record
+# Use mysql as the database for Active Record	
 gem 'mysql2', '>= 0.4.4'
 # Use Puma as the app server
 gem 'puma', '~> 4.3'

--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -8,7 +8,7 @@ class KeysController < ApplicationController
     token = if Rails.env.production?
       Rails.application.credentials.key_claim_token
     else
-      'test'
+      ENV['KEY_CLAIM_TOKEN']
     end
     header = {'Authorization': "Bearer #{token}" }
     http = Net::HTTP.new(uri.host, uri.port)

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,9 +13,10 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password:
-  host: portal.railgun
+  username: <%= ENV.fetch("DATABASE_USERNAME") { 'root' } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { '' } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { 'localhost' } %>
+  port: <%= ENV.fetch("DATABASE_PORT") { 3306 } %>
 
 development:
   <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,4 +109,9 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  Rails.application.config.session_store :cookie_store,
+                                       key: '_portal_session',
+                                       expire_after: 7. days,
+                                       secure: false,
+                                       same_site: :lax
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,0 @@
-Rails.application.config.session_store :cookie_store,
-                                       key: '_portal_session',
-                                       expire_after: 7. days,
-                                       secure: true,
-                                       same_site: :lax

--- a/dev.yml
+++ b/dev.yml
@@ -33,8 +33,9 @@ commands:
     run: bin/rails test
 
 env:
-  KEY_CLAIM_TOKEN: test
+  KEY_CLAIM_TOKEN: thisisatoken
   KEY_CLAIM_HOST: covidshield-submit.myshopify.io
+  DATABASE_HOST: portal.railgun
 
 # These use fuzzy-matching, so you can (e.g.) `dev open app`
 open:

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -42,9 +42,8 @@ class UsersTest < ApplicationSystemTestCase
   test "deleting a user" do
     login_as_admin
     visit users_url
-    page.accept_confirm do
-      click_on "Remove", match: :first
-    end
+    click_on "Remove", match: :first
+    click_on "Remove user", match: :first
 
     assert_selector "h1", text: "Manage users"
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,6 @@ class ActiveSupport::TestCase
   fixtures :all
 
   def sign_in_as(user)
-    session[:user_id] = user.id
+    post sessions_url, params: { username: user.username, password: 'secret' }
   end
 end


### PR DESCRIPTION
This fixes a few things that were causing issues for our tests and sets up a github action to run them in CI.

First, the [session store initializer](https://github.com/CovidShield/portal/pull/58/files#diff-ae8f555b82c0416edbcf62c9c1a5b73b) was causing issues for dev and test because it relied on SSL so I moved it to only the production environment.

It also moves some of the database config to env variables so we can have more control in both CI and for others who are developing locally with other setups.

Finally, I setup a github action to run all of our tests in CI so that we can avoid these kinds of regressions in the future.