### PR TITLE
Adding better error handling for key claim

### DIFF
--- a/app/assets/stylesheets/components/code-generator.scss
+++ b/app/assets/stylesheets/components/code-generator.scss
@@ -25,6 +25,12 @@
   letter-spacing: 0;
 }
 
+.code-generator__banner--error {
+  background-color: rgba($color-red, 0.1);
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
 .code-generator__result {
   font-weight: normal;
 }

--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -15,6 +15,12 @@ class KeysController < ApplicationController
     http.use_ssl = uri.scheme == 'https'
     request = Net::HTTP::Post.new(uri.request_uri, header)
     response = http.request(request)
+
+    if response.code != '200'    
+      render status: response.code
+      return
+    end
+
     @key = response.body
     render text: @key
   end

--- a/app/javascript/components/code-generator.js
+++ b/app/javascript/components/code-generator.js
@@ -62,6 +62,8 @@ export function initializeCodeGenerator() {
     if (!response || response.status !== 200) {
       codeBanner.dataset.hidden = "true";
       delete errorMessage.dataset.hidden;
+      errorMessage.tabIndex = -1;
+      errorMessage.focus();
       generateButton.disabled = false;
       return;
     }

--- a/app/javascript/components/code-generator.js
+++ b/app/javascript/components/code-generator.js
@@ -71,6 +71,7 @@ export function initializeCodeGenerator() {
     const data = await response.json();
 
     expiredMessage.dataset.hidden = "true";
+    errorMessage.dataset.hidden = "true";
     emptyResult.dataset.hidden = "true";
     delete codeBanner.dataset.hidden;
     codeResult.innerHTML = formatCode(data.key);

--- a/app/javascript/components/code-generator.js
+++ b/app/javascript/components/code-generator.js
@@ -10,7 +10,7 @@ async function postData() {
       "Content-Type": "application/json",
     },
   });
-  return response.json();
+  return response;
 }
 
 function formatCode(code) {
@@ -25,8 +25,15 @@ export function initializeCodeGenerator() {
   const resetButton = document.querySelector("[data-reset-code]");
   const codeBanner = document.querySelector("[data-code-banner]");
   const expiredMessage = document.querySelector("[data-code-expired]");
+  const errorMessage = document.querySelector("[data-code-error]");
 
-  if (!generateButton || !resetButton || !codeBanner || !expiredMessage) {
+  if (
+    !generateButton ||
+    !resetButton ||
+    !codeBanner ||
+    !expiredMessage ||
+    !errorMessage
+  ) {
     return;
   }
 
@@ -50,27 +57,34 @@ export function initializeCodeGenerator() {
 
   generateButton.addEventListener("click", async function () {
     generateButton.disabled = true;
-    const data = await postData();
+    const response = await postData();
 
-    if (data) {
-      expiredMessage.dataset.hidden = "true";
-      emptyResult.dataset.hidden = "true";
-      delete codeBanner.dataset.hidden;
-      codeResult.innerHTML = formatCode(data.key);
-
-      generateContent.dataset.hidden = "true";
-      delete generateNewContent.dataset.hidden;
-
+    if (!response || response.status !== 200) {
+      codeBanner.dataset.hidden = "true";
+      delete errorMessage.dataset.hidden;
       generateButton.disabled = false;
-      resetButton.disabled = false;
-
-      window.clearTimeout(codeTimeout);
-
-      codeTimeout = window.setTimeout(() => {
-        codeBanner.dataset.hidden = "true";
-        delete expiredMessage.dataset.hidden;
-      }, CODE_TIMEOUT);
+      return;
     }
+
+    const data = await response.json();
+
+    expiredMessage.dataset.hidden = "true";
+    emptyResult.dataset.hidden = "true";
+    delete codeBanner.dataset.hidden;
+    codeResult.innerHTML = formatCode(data.key);
+
+    generateContent.dataset.hidden = "true";
+    delete generateNewContent.dataset.hidden;
+
+    generateButton.disabled = false;
+    resetButton.disabled = false;
+
+    window.clearTimeout(codeTimeout);
+
+    codeTimeout = window.setTimeout(() => {
+      codeBanner.dataset.hidden = "true";
+      delete expiredMessage.dataset.hidden;
+    }, CODE_TIMEOUT);
   });
 
   resetButton.addEventListener("click", async function () {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -89,6 +89,9 @@
                   <div class="code-generator__banner code-generator__banner--expired" data-code-expired data-hidden>
                     <%= t('home.card3.step4_code_expired') %>
                   </div>
+                  <div class="code-generator__banner code-generator__banner--error" data-code-error data-hidden>
+                    <%= t('home.card3.step4_code_error') %>
+                  </div>
                   <div class="code-generator__button">
                     <button type="button" class="button" data-generate-code aria-controls="code-result">
                       <span data-generate-content><%= t('home.card3.step4_generate_code') %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
       step3_modal_content_html: "Tap the <strong>Enter code</strong> button."
       step3_modal_alt: "Screenshot of COVID Shield mobile app with Enter code button highlighted"
       step4: "Enter the following 8 digit code:"
+      step4_code_error: "There was an error generating a code."
       step4_code_expired: "This code has expired."
       step4_generate_code: "Generate code"
       step4_generated_code: "Generated code"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
       step3_modal_content_html: "Tap the <strong>Enter code</strong> button."
       step3_modal_alt: "Screenshot of COVID Shield mobile app with Enter code button highlighted"
       step4: "Enter the following 8 digit code:"
-      step4_code_error: "There was an error generating a code."
+      step4_code_error: "There was an error generating a code. Please try again."
       step4_code_expired: "This code has expired."
       step4_generate_code: "Generate code"
       step4_generated_code: "Generated code"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,6 +65,7 @@ fr:
       step3_modal_content_html: "Appuyer sur le bouton <strong>Entrez le code</strong>."
       step3_modal_alt: "Capture d'écran de l'application mobile COVID Shield avec le bouton Entrez le code encadré"
       step4: "Entrer le code à 8 chiffres suivant :"
+      step4_code_error: "Une erreur s'est produite lors de la génération d'un code."
       step4_code_expired: "Ce code est expiré."
       step4_generate_code: "Générer un code"
       step4_generated_code: "Code généré"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,7 +65,7 @@ fr:
       step3_modal_content_html: "Appuyer sur le bouton <strong>Entrez le code</strong>."
       step3_modal_alt: "Capture d'écran de l'application mobile COVID Shield avec le bouton Entrez le code encadré"
       step4: "Entrer le code à 8 chiffres suivant :"
-      step4_code_error: "Une erreur s'est produite lors de la génération d'un code."
+      step4_code_error: "Une erreur s'est produite lors de la génération d'un code. Veuillez réessayer."
       step4_code_expired: "Ce code est expiré."
       step4_generate_code: "Générer un code"
       step4_generated_code: "Code généré"

--- a/test/controllers/keys_controller_test.rb
+++ b/test/controllers/keys_controller_test.rb
@@ -20,4 +20,14 @@ class KeysControllerTest < ActionDispatch::IntegrationTest
     post keys_generate_url format: 'json'
     assert_response :success, {key: "12345678"}
   end
+
+  test "server status code is forwarded to response" do
+    request_url = "https://" + ENV['KEY_CLAIM_HOST'] + "/new-key-claim";
+    stub_request(:post, request_url).
+      to_return(status: 403)
+
+    sign_in_as(@user)
+    post keys_generate_url format: 'json'
+    assert_response 403
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -23,6 +23,18 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_selector "[data-code-result]"
   end
 
+  test "code generation error is displayed" do
+    request_url = "https://" + ENV['KEY_CLAIM_HOST'] + "/new-key-claim";
+    stub_request(:post, request_url).
+      to_return(status: 403)
+
+    login_as_admin
+    visit root_url
+    click_on "Generate code"
+
+    assert_selector "[data-code-error]:not([data-hidden])"
+  end
+
   test "menu popover works for admins" do
     login_as_admin
     visit root_url


### PR DESCRIPTION
This adds an error message to the front end of the portal when a key can't be claimed from the server.

This is what it looks like:

<img width="720" alt="Screen Shot 2020-05-27 at 8 45 06 PM" src="https://user-images.githubusercontent.com/478990/83149425-0a9a2900-a0c8-11ea-8696-820120b9cd94.png">

To test:

Checkout this branch and change the `KEY_CLAIM_TOKEN` env variable to something invalid. Try running the portal and generating a code.

@emilybulger I added a simple error message and my best stab at a translation in French. Would love your feedback on this.