### PR TITLE
Only lint when Dockerfile changes

### DIFF
--- a/.github/workflows/hadolint-ci.yml
+++ b/.github/workflows/hadolint-ci.yml
@@ -1,5 +1,11 @@
 name: Lint Dockerfile
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "Dockerfile"
+  pull_request:
+    paths:
+      - "Dockerfile"
 
 jobs:
   linter:


### PR DESCRIPTION
If I understand correctly, the linter only looks at the Dockerfile, so it should really only run when that file is changed.