### PR TITLE
prevent marking of last admin as staff

### DIFF
--- a/app/assets/stylesheets/components/text-field.scss
+++ b/app/assets/stylesheets/components/text-field.scss
@@ -30,6 +30,16 @@
   }
 }
 
+.select-form--error {
+  .select__label {
+    color: $color-red;
+  }
+
+  .select {
+    border-color: $color-red;
+  }
+}
+
 .text-field__error-message {
   color: $color-red;
   margin-top: $spacing-tight;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
     else
       @page_title = "#{I18n.t('settings.title')} | #{I18n.t('title')}"
     end
-    
+
 
     if !current_user.admin && current_user != @user
       redirect_to root_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,14 @@ module ApplicationHelper
 
     classnames.join(' ')
   end
+
+  def select_classes(errors)
+    classnames = ['select-form']
+
+    if errors.any?
+      classnames.push('select-form--error')
+    end
+
+    classnames.join(' ')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,18 @@ class User < ApplicationRecord
   has_secure_password
 
   validates :username, presence: true, uniqueness: {case_sensitive: true}
+
+  validate :at_least_one_admin?, on: :update
+
+  scope :admin, -> { where(admin: true) }
+
+  private
+
+  def at_least_one_admin?
+    errors.add(:admin, 'At least one admin user must exist.') if removes_last_admin
+  end
+
+  def removes_last_admin
+    admin_changed? && User.admin.count == 1 && admin == false
+  end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -25,7 +25,7 @@
           </div>
         </div>
       </div>
-      
+
       <div class="grid">
         <div class="grid__item grid__item--half">
           <div class="<%= text_field_classes(user.errors[:password]) %>">
@@ -64,11 +64,23 @@
       <%  if current_user.admin %>
         <div class="grid">
           <div class="grid__item grid__item--half">
-            <%= form.label :admin, t('user_form.permissions_label'), class: 'select__label' %>
-            <%= form.select(:admin, [[t('staff'), false], [t('admin'), true]], {}, class: 'select') %>
+            <div class="<%= select_classes(user.errors[:admin]) %>">
+              <%= form.label :admin, t('user_form.permissions_label'), class: 'select__label' %>
+              <%= form.select :admin,
+                [[t('staff'), false], [t('admin'), true]], {},
+                class: 'select',
+                'aria-describedby': (user.errors[:admin].any? ? 'admin-error' : nil),
+                'aria-invalid': (user.errors[:admin].any? ? true : nil)
+              %>
+              <% if user.errors[:admin].any? %>
+                <small id="admin-error" class="text-field__error-message">
+                  <%= user.errors[:admin].join(',') %>
+                </small>
+              <% end %>
+            </div>
           </div>
         </div>
-      <% end %>    
+      <% end %>
     </div>
     <div class="card__footer">
       <div class="card__footer-actions">

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -75,6 +75,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to users_url
   end
 
+  test "admin cannot mark as staff if they are the only admin" do
+    sign_in_as(@admin)
+    assert_equal(1, User.where(admin: true).count)
+    patch user_url(@admin), params: { user: { admin: false } }
+    @admin.reload
+    assert @admin.admin
+  end
+
   test "staff should not be able to update user" do
     sign_in_as(@staff)
     patch user_url(@bob), params: { user: { id: @bob.id, username: @bob.username } }
@@ -87,7 +95,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     @staff.reload
     assert_equal 'staff2', @staff.username
-    
+
     assert_redirected_to root_url
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,19 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @admin = users(:admin)
+    @staff = users(:staff)
+  end
+
+  test "cannot update the last admin to be staff" do
+    assert User.admin.count == 1
+    @admin.admin = false
+    refute @admin.save
+  end
+
+  test "can revert admin to staff if there is another admin" do
+    @staff.update(admin: true)
+    assert @admin.update(admin: false)
+  end
 end


### PR DESCRIPTION
This PR checks to see if an update will mark the last admin as staff. If it does it adds an error and returns the user to the edit page. Also added some styling to show the error.

<img width="608" alt="Screen Shot 2020-06-19 at 3 44 40 PM" src="https://user-images.githubusercontent.com/16342033/85174815-21094f80-b244-11ea-8241-72a9b45cf85b.png">

resolves https://github.com/CovidShield/portal/issues/92