### PR TITLE
turn on force ssl in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
I think this resolves https://github.com/CovidShield/portal/issues/93 - what do you think @honkfestival ? Should we put together a guide for using SSL? I think it depends on what the people who might actually run the portal need.

Configuring the portal to force the use of SSL in production will ensure that deployments configure SSL. If this isn't turned on our application won't force redirect to `https` in production or use secure cookies, etc.